### PR TITLE
add `census_tiledb_training_atlas_scale_models`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = cookiecutter
 	url = https://github.com/scverse/cookiecutter-scverse-presentation.git
 	branch = gh-pages
+[submodule "census_tiledb_training_atlas_scale_models"]
+	path = census_tiledb_training_atlas_scale_models
+	url = https://github.com/TileDB-Inc/scverse-ml-workshop-2024


### PR DESCRIPTION
Started adding links/materials from the [Training models on atlas-scale single-cell datasets] workshop, but it was mostly duplicative of things already in our repo, [TileDB-Inc/scverse-ml-workshop-2024].

Adding that repo as a submodule here instead, lmk if you prefer something else!

cc @spencerseale, @MaximilianLombardo
        

[Training models on atlas-scale single-cell datasets]: https://cfp.scverse.org/2024/talk/GQHNYE/
[TileDB-Inc/scverse-ml-workshop-2024]: https://github.com/TileDB-Inc/scverse-ml-workshop-2024